### PR TITLE
fix: correct secret_id indexing for secrets-manager resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_secretsmanager_secret" "main" {
 resource "aws_secretsmanager_secret_version" "sm-sv" {
   count = var.unmanaged && var.enabled ? 0 : length(local.secrets)
 
-  secret_id     = aws_secretsmanager_secret.main[0].id
+  secret_id     = aws_secretsmanager_secret.main[count.index].id
   secret_string = lookup(element(local.secrets, count.index), "secret_string")
   secret_binary = lookup(element(local.secrets, count.index), "secret_binary") != null ? base64encode(lookup(element(local.secrets, count.index), "secret_binary")) : null
   depends_on    = [aws_secretsmanager_secret.main]
@@ -69,7 +69,7 @@ resource "aws_secretsmanager_secret_version" "sm-sv" {
 
 resource "aws_secretsmanager_secret_version" "sm-svu" {
   count         = var.unmanaged && var.enabled ? length(local.secrets) : 0
-  secret_id     = aws_secretsmanager_secret.main[*].id[count.index]
+  secret_id     = aws_secretsmanager_secret.main[count.index].id
   secret_string = lookup(element(local.secrets, count.index), "secret_string")
   secret_binary = lookup(element(local.secrets, count.index), "secret_binary") != null ? base64encode(lookup(element(local.secrets, count.index), "secret_binary")) : null
   depends_on    = [aws_secretsmanager_secret.main]
@@ -88,7 +88,7 @@ resource "aws_secretsmanager_secret_version" "sm-svu" {
 resource "aws_secretsmanager_secret_rotation" "main" {
   count               = var.enabled && var.enable_rotation ? 1 : 0
   rotation_lambda_arn = var.rotation_lambda_arn
-  secret_id           = aws_secretsmanager_secret.main[*].id
+  secret_id           = aws_secretsmanager_secret.main[count.index].id
   dynamic "rotation_rules" {
     for_each = [var.rotation_rules]
     content {


### PR DESCRIPTION
## 📌 Description

- This PR resolves bad indexing for `aws_secretsmanager_secret.main` which was throwing below error
```bash
╷
│ Error: Incorrect attribute value type
│ 
│   on .terraform/modules/secrets_manager/main.tf line 91, in resource "aws_secretsmanager_secret_rotation" "main":
│   91:   secret_id           = aws_secretsmanager_secret.main[*].id
│     ├────────────────
│     │ aws_secretsmanager_secret.main is tuple with 1 element
│ 
│ Inappropriate value for attribute "secret_id": string required, but have tuple.
```
---

## 🔄 Type of Change

<!-- Select all applicable options -->

* [x] 🐛 Bug fix (non-breaking change)
* [ ] ✨ New resource / feature
* [ ] ♻️ Refactoring
* [ ] ⚡ Performance improvement
* [ ] 🔒 Security improvement
* [ ] 📝 Documentation update
* [ ] ⚠️ BREAKING CHANGE
* [ ] ⚙️ CI/CD update

---

## 🌍 Terraform Scope

<!-- Indicate the area impacted by this PR -->

* [ ] New resource added
* [x] Existing resource updated
* [ ] Variable(s) modified
* [ ] Output(s) modified
* [ ] Provider / backend configuration change
* [ ] CI/CD (Terraform workflow) update
* [ ] Examples / usage updated

---

## ✅ Checklist

<!-- Ensure all items are completed before requesting review -->

* [x] Code follows Terraform best practices
* [x] `terraform fmt -recursive` and `terraform validate` have been executed
* [x] `terraform plan` has been reviewed and changes are expected
* [ ] Changes are backward compatible (or breaking changes are clearly documented)
* [ ] Documentation has been updated (README, examples, etc.)
* [ ] Variables and outputs are properly defined and documented
* [x] No sensitive data (secrets, credentials, keys) is exposed

---

## 🧩 Terraform Version & Providers

<!-- Specify versions used for validation/testing -->

* Terraform Version:
* Provider(s):

---

## 🧪 Testing

<!-- Describe how you validated your changes -->

* [ ] Tested locally using `terraform plan` / `apply`
* [ ] Tested in a staging / sandbox environment (if applicable)

**Test Details:**

<!-- Include commands, environment details, or notes -->

---

## 📸 Screenshots / Documentation

<!-- Add screenshots or documentation references if applicable -->

---

## 🔗 Related Issues

<!-- Link related issues using #issue_number -->

Closes #

---

## 📝 Additional Notes

<!-- Add any additional context, limitations, or reviewer guidance -->